### PR TITLE
Disable force_ssl

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,7 +51,7 @@ Rails.application.configure do
   # config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  # config.force_ssl = true
 
   # Log to STDOUT by default
   config.logger = ActiveSupport::Logger.new($stdout)


### PR DESCRIPTION
The backend being accessed using plain HTTP causes the /up endpoint based proxy health check to fail because of it redirecting to HTTPS instead of returning 200.

Better ways to solve this:
- use HTTPS for backend connectivity
- disable the redirect only for /up

The former is not yet implemented in our infrastructure. The latter I don't know how to do.

Since our reverse proxy redirects traffic originating from real users to HTTPS anyways, aligning the force_ssl setting with paste-o-o, which has it commented out as well, is deemed feasible.