### PR TITLE
Move month title to top of cell to align with first day

### DIFF
--- a/app/assets/stylesheets/calendar.scss
+++ b/app/assets/stylesheets/calendar.scss
@@ -36,7 +36,6 @@
   .month {
     grid-column-start: 1;
     display: flex;
-    align-items: end;
   }
 
   @for $i from 1 through 7 {


### PR DESCRIPTION
Suggested by knurpht, is not pixel aligned but close enough.