### PR TITLE
Repair invalid sign_out route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
   devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
 
   devise_scope :user do
-    delete '/users/sign_out' => 'devise/sessions#destroy', as: :destroy_user_session
+    delete '/users/sign_out', to: 'devise/sessions#destroy'
   end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 


### PR DESCRIPTION
Resolve
"`add_route': Invalid route name, already in use: 'destroy_user_session' (ArgumentError)" under Rails 3.x.