### PR TITLE
Revert "Add bundle install to development steps"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,6 @@ cd calendar-o-o
 cp config/database.sample.yml config/database.yml
 cp config/site.sample.yml config/site.yml
 docker-compose build
-docker-compose run web bundle install --path /bundler/vendor --jobs=3 --retry=3
 docker-compose run web bin/rails db:create db:migrate
 docker-compose up
 ```


### PR DESCRIPTION
This reverts commit 5e2a4053b8b35635c9f63c237aba72fe8dd10d58. The steps seem no longer necessary and will in fact fail with permission errors due to it attempting writes to system directories. Cannot explain this.