### PR TITLE
Validate occurrence date input

### DIFF
--- a/app/javascript/controllers/occurrence_controller.js
+++ b/app/javascript/controllers/occurrence_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [ "destroy", "time" ]
+
+  connect() {
+    this.toggleRequired()
+  }
+
+  toggleRequired() {
+    this.timeTarget.required = !this.destroyTarget.checked
+  }
+}

--- a/app/models/event_occurrence.rb
+++ b/app/models/event_occurrence.rb
@@ -6,6 +6,8 @@ class EventOccurrence < ApplicationRecord
 
   belongs_to :event
 
+  validates :time, presence: true
+
   def exclude
     event.schedule_exceptions << ScheduleException.new(time: starts_at)
     event.save!

--- a/app/views/schedule_occurrences/_form.html.haml
+++ b/app/views/schedule_occurrences/_form.html.haml
@@ -1,13 +1,15 @@
 = fields_for "event[schedule_occurrences_attributes][#{index}]", occurrence do |fr|
   = fr.hidden_field(:id, value: fr.object.id) if fr.object
-  .row
+  .row{ data: { controller: 'occurrence' } }
     .col
       .form-floating
-        = fr.datetime_local_field :time, class: 'form-control'
+        = fr.datetime_local_field :time, class: 'form-control', required: true,
+                                         data: { occurrence_target: 'time' }
         = fr.label :time, t('schedule_occurrences.time')
     .col-auto
       .form-destroy
-        = fr.check_box :_destroy, class: 'form-check-input'
+        = fr.check_box :_destroy, class: 'form-check-input',
+                                  data: { occurrence_target: 'destroy', action: 'change->occurrence#toggleRequired' }
         = fr.label :_destroy, t('schedule_occurrences.remove'), class: 'form-check-disabled'
         = fr.label :_destroy, t('schedule_occurrences.restore'), class: 'form-check-enabled'
     %hr.mt-3


### PR DESCRIPTION
Prevent users from adding schedule_occurrences entries without a time, as NULL time entries cause ICS rendering to fail.

Link: https://progress.opensuse.org/issues/176724