### PR TITLE
Repair input validation expressions

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -18,7 +18,7 @@ class Event < ApplicationRecord
                                 allow_destroy: true
 
   validates :slug,
-            format: { with: /\A[a-z0-9_-]+\z/, message: I18n.t('format_validation.alphanumeric_with_dashes') }
+            format: { with: /\A[a-z0-9_\-]+\z/, message: I18n.t('format_validation.alphanumeric_with_dashes') }
   validates :slug, uniqueness: { scope: :team_id }
 
   after_save :populate_occurrences

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -12,7 +12,7 @@ class Team < ApplicationRecord
   enum :color, %w[pink red orange yellow green blue indigo purple]
 
   validates :slug,
-            format: { with: /\A[a-z0-9_-]+\z/, message: I18n.t('format_validation.alphanumeric_with_dashes') }
+            format: { with: /\A[a-z0-9_\-]+\z/, message: I18n.t('format_validation.alphanumeric_with_dashes') }
 
   COLOR = { pink: '#e83ed4',
             red: '#e01b24',

--- a/app/views/events/edit.html.haml
+++ b/app/views/events/edit.html.haml
@@ -13,7 +13,7 @@
     = f.label :name, t('events.name')
   .form-floating.mb-3
     = f.text_field :slug, required: true, class: 'form-control', placeholder: t('events.slug'),
-                          pattern: '^[a-z0-9_-]+$'
+                          pattern: '^[a-z0-9_\-]+$'
     = f.label :slug, t('events.slug')
   .form-floating.mb-3
     = f.text_area :description, class: 'form-control h-min mb-1', placeholder: t('events.description')

--- a/app/views/events/new.html.haml
+++ b/app/views/events/new.html.haml
@@ -11,7 +11,7 @@
     = f.label :name, t('events.name')
   .form-floating.mb-3
     = f.text_field :slug, required: true, class: 'form-control', placeholder: t('events.slug'),
-                          pattern: '^[a-z0-9_-]+$',
+                          pattern: '^[a-z0-9_\-]+$',
                           data: { 'slug-form-target': 'slug' }
     = f.label :slug, t('events.slug')
   .form-floating.mb-3

--- a/app/views/teams/edit.html.haml
+++ b/app/views/teams/edit.html.haml
@@ -10,7 +10,7 @@
     = f.label :name, t('events.name')
   .form-floating.mb-3
     = f.text_field :slug, required: true, class: 'form-control', placeholder: t('events.slug'),
-                          pattern: '^[a-z0-9_-]+$', data: { 'slug-form-target': 'slug' }
+                          pattern: '^[a-z0-9_\-]+$', data: { 'slug-form-target': 'slug' }
     = f.label :slug, t('events.slug')
   .input-group.mb-3
     = f.collection_radio_buttons :color, Team.colors.keys, :to_s, :humanize do |fc|

--- a/app/views/teams/new.html.haml
+++ b/app/views/teams/new.html.haml
@@ -10,7 +10,7 @@
     = f.label :name, t('events.name')
   .form-floating.mb-3
     = f.text_field :slug, required: true, class: 'form-control', placeholder: t('events.slug'),
-                          pattern: '^[a-z0-9_-]+$', data: { 'slug-form-target': 'slug' }
+                          pattern: '^[a-z0-9_\-]+$', data: { 'slug-form-target': 'slug' }
     = f.label :slug, t('events.slug')
   .input-group.mb-3
     = f.collection_radio_buttons :color, Team.colors.keys, :to_s, :humanize do |fc|


### PR DESCRIPTION
Browsers reported

```
Unable to check <input pattern=‘^[a-z0-9_-]+$’> because ‘/^[a-z0-9_-]+$/v’ is not a valid regexp: invalid character in class in regular expression
```

due to the special interpretation of hyphens.