### PR TITLE
Repair sign_out route (again)

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,8 +17,10 @@ Rails.application.routes.draw do
 
   devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
 
-  devise_scope :user do
-    delete '/users/sign_out', to: 'devise/sessions#destroy'
+  unless Rails.configuration.site.dig(:authentication, :local)
+    devise_scope :user do
+      delete '/users/sign_out' => 'devise/sessions#destroy', as: :destroy_user_session
+    end
   end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 


### PR DESCRIPTION
For some reason, this stopped working, and now reported "ActionView::Template::Error (undefined local variable or method `destroy_user_session_path'" upon attempting to render the _navbar after OIDC login.

In Devise, "destroy_user_session_path" appears to be inherited from its "sessions" controller, which is only loaded with the "database_authenticatable" module - not with "omniauthable". Our User model conditionalizes the addition of "database_authenticatable" (amongst others) to the "local" authentication method.

This means:
- For OIDC (aka omniauthable) authentication, destroy_user_session does not exist by default, and must be explicitly declared.
- For local (aka database_authenticatable) authentication, destroy_user_session is implied and must not be (re-)declared.

To solve this, enabling the route for both OIDC and local authentication, partially revert commit d713e731a8f4e1ea5af0f4bb07b152218a763c78, but conditionalize the block in alignment with the conditional inside User class.