### PR TITLE
Move time validation to correct model

### DIFF
--- a/app/models/event_occurrence.rb
+++ b/app/models/event_occurrence.rb
@@ -6,8 +6,6 @@ class EventOccurrence < ApplicationRecord
 
   belongs_to :event
 
-  validates :time, presence: true
-
   def exclude
     event.schedule_exceptions << ScheduleException.new(time: starts_at)
     event.save!

--- a/app/models/schedule_occurrence.rb
+++ b/app/models/schedule_occurrence.rb
@@ -4,6 +4,8 @@
 class ScheduleOccurrence < ApplicationRecord
   belongs_to :event
 
+  validates :time, presence: true
+
   def time
     super&.in_time_zone(event.timezone)
   end


### PR DESCRIPTION
~To resolve issues caused by nil times, validation was added in both the frontend and the model. The model validation however causes updates to events with recurrences to fail due to
"NoMethodError (undefined method `time' for #<EventOccurrence ..." during populate_occurrences.
Solve this by reverting the model validation part and assuming the frontend validation to be sufficient.~

EventOccurrence does not have :time - ScheduleOccurrence does.

Fixes: 2d50cd201e6b ("Validate occurrence date input")