### PR TITLE
Have Dependabot combine rubocop updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,9 @@ updates:
     schedule:
       interval: "daily"
     vendor: true
+
+    groups:
+      rubocop:
+        patterns:
+          - "rubocop"
+          - "rubocop-*"


### PR DESCRIPTION
These tend to depend on each other, i.e. an updated rubocop may fail to run if the other rubocop packages are not updated too.